### PR TITLE
comparing classes full qualified names instead of class. There are cases...

### DIFF
--- a/src/main/java/br/com/bfmapper/Mapping.java
+++ b/src/main/java/br/com/bfmapper/Mapping.java
@@ -278,7 +278,8 @@ public class Mapping implements Serializable {
 		
 		Class<?> sourceConverter = converter.getSourceClass();
 		Class<?> targetConverter = converter.getTargetClass();
-		return (sourceClass.equals(sourceConverter) && targetClass.equals(targetConverter)) || (targetClass.equals(sourceConverter) && sourceClass.equals(targetConverter));		
+		
+		return (sourceClass.getName().equals(sourceConverter.getName()) && targetClass.getName().equals(targetConverter.getName())) || (targetClass.getName().equals(sourceConverter.getName()) && sourceClass.getName().equals(targetConverter.getName()));
 	}
 	
 	private void evalEqualsProperties(Object source, Object target, Converter converter) {


### PR DESCRIPTION
Comparing classes full qualified names instead of class. There are cases where the MappingRules defined class is loaded in a different classloader then the application.

Classes from MappingRules are loaded in `sun.misc.Launcher$AppClassLoader` and application classes are loaded from `WebappClassLoader`.
